### PR TITLE
feat: pager, summary footer, and compact mode for browsing

### DIFF
--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,15 +1,19 @@
 use std::collections::HashSet;
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal, Write};
 
 use anyhow::ensure;
 
 use crate::data::BlogData;
 use crate::data::schema::FeedItem;
-use crate::display::{RenderCtx, render_grouped};
-use crate::query::Query;
+use crate::display::{RenderCtx, Style, render_grouped};
+use crate::query::{Query, ReadFilter};
 use crate::query::resolve::resolve_posts;
 
-pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
+pub(crate) struct ShowOpts {
+    pub compact: bool,
+}
+
+pub(crate) fn cmd_show(store: &BlogData, query: &Query, opts: &ShowOpts) -> anyhow::Result<()> {
     let resolved = resolve_posts(store, query)?;
     ensure!(!resolved.items.is_empty(), "No matching posts");
 
@@ -20,7 +24,8 @@ pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
         .collect();
 
     let color = std::io::stdout().is_terminal();
-    let max_width = terminal_size::terminal_size().map(|(w, _)| w.0 as usize);
+    let terminal = terminal_size::terminal_size();
+    let max_width = terminal.map(|(w, _)| w.0 as usize);
     let refs: Vec<&FeedItem> = resolved.items.iter().map(|(_, item)| item).collect();
     let ctx = RenderCtx {
         all_keys: &query.keys,
@@ -30,7 +35,220 @@ pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
         color,
         shorthand_width: RenderCtx::shorthand_width_from(&refs, &resolved.shorthands),
         max_width,
+        compact: opts.compact,
     };
-    print!("{}", render_grouped(&refs, &ctx));
+
+    let mut output = render_grouped(&refs, &ctx);
+    // Trim trailing blank lines from grouped output before appending summary
+    let trimmed_len = output.trim_end().len();
+    output.truncate(trimmed_len);
+    output.push('\n');
+
+    output.push_str(&format_summary(&refs, &read_ids, query, color));
+
+    let is_tty = std::io::stdout().is_terminal();
+    let term_height = terminal.map(|(_, h)| h.0 as usize).unwrap_or(usize::MAX);
+    let line_count = output.lines().count();
+
+    if is_tty && line_count > term_height {
+        if output_with_pager(&output).is_err() {
+            print!("{output}");
+        }
+    } else {
+        print!("{output}");
+    }
+
     Ok(())
+}
+
+pub(crate) fn format_summary(
+    items: &[&FeedItem],
+    read_ids: &HashSet<String>,
+    query: &Query,
+    color: bool,
+) -> String {
+    let count = items.len();
+    let feed_count = {
+        let mut feeds: Vec<&str> = items.iter().map(|i| i.feed.as_str()).collect();
+        feeds.sort_unstable();
+        feeds.dedup();
+        feeds.len()
+    };
+
+    let status = match query.read_filter {
+        ReadFilter::Unread => " unread",
+        ReadFilter::Read => " read",
+        // Any = default filter (.unread in default_query), count what's actually shown
+        ReadFilter::Any => {
+            let unread_count = items.iter().filter(|i| !read_ids.contains(&i.raw_id)).count();
+            if unread_count == count {
+                " unread"
+            } else {
+                ""
+            }
+        }
+        ReadFilter::All => "",
+    };
+
+    let post_word = if count == 1 { "post" } else { "posts" };
+    let feed_word = if feed_count == 1 { "feed" } else { "feeds" };
+
+    let s = Style::new(color);
+    format!(
+        "\n{}{count}{status} {post_word} \u{00b7} {feed_count} {feed_word}{}\n",
+        s.dim, s.reset
+    )
+}
+
+fn output_with_pager(content: &str) -> io::Result<()> {
+    let pager_env = std::env::var("PAGER").ok();
+    let (bin, args) = match &pager_env {
+        Some(val) => {
+            let val = val.trim();
+            match val.split_once(char::is_whitespace) {
+                Some((b, a)) => (b.to_string(), vec![a.to_string()]),
+                None => {
+                    let mut args = Vec::new();
+                    if val == "less" {
+                        args.push("-R".to_string());
+                    }
+                    (val.to_string(), args)
+                }
+            }
+        }
+        None => ("less".to_string(), vec!["-R".to_string()]),
+    };
+
+    let mut child = std::process::Command::new(&bin)
+        .args(&args)
+        .stdin(std::process::Stdio::piped())
+        .spawn()?;
+
+    let result = child.stdin.as_mut().unwrap().write_all(content.as_bytes());
+
+    // Ignore broken pipe — user quit the pager early, which is intentional
+    if let Err(ref e) = result {
+        if e.kind() != io::ErrorKind::BrokenPipe {
+            result?;
+        }
+    }
+
+    // Drop stdin to signal EOF
+    drop(child.stdin.take());
+
+    let _ = child.wait();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::DateFilter;
+
+    fn make_item(title: &str, feed: &str, raw_id: &str) -> FeedItem {
+        FeedItem {
+            title: title.to_string(),
+            date: None,
+            feed: feed.to_string(),
+            link: String::new(),
+            raw_id: raw_id.to_string(),
+        }
+    }
+
+    fn make_query(read_filter: ReadFilter) -> Query {
+        Query {
+            keys: vec![],
+            filter: None,
+            id_filter: None,
+            date_filter: DateFilter {
+                since: None,
+                until: None,
+            },
+            shorthands: vec![],
+            read_filter,
+        }
+    }
+
+    #[test]
+    fn test_format_summary_unread() {
+        let items = vec![
+            make_item("A", "feed1", "id-a"),
+            make_item("B", "feed2", "id-b"),
+            make_item("C", "feed1", "id-c"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let mut read_ids = HashSet::new();
+        read_ids.insert("id-b".to_string());
+
+        let q = make_query(ReadFilter::Unread);
+        let summary = format_summary(&refs, &read_ids, &q, false);
+        assert_eq!(summary, "\n3 unread posts \u{00b7} 2 feeds\n");
+    }
+
+    #[test]
+    fn test_format_summary_all() {
+        let items = vec![make_item("A", "feed1", "id-a")];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let read_ids = HashSet::new();
+
+        let q = make_query(ReadFilter::All);
+        let summary = format_summary(&refs, &read_ids, &q, false);
+        assert_eq!(summary, "\n1 post \u{00b7} 1 feed\n");
+    }
+
+    #[test]
+    fn test_format_summary_singular() {
+        let items = vec![make_item("A", "feed1", "id-a")];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let read_ids = HashSet::new();
+
+        let q = make_query(ReadFilter::Unread);
+        let summary = format_summary(&refs, &read_ids, &q, false);
+        assert_eq!(summary, "\n1 unread post \u{00b7} 1 feed\n");
+    }
+
+    #[test]
+    fn test_format_summary_read_filter() {
+        let items = vec![
+            make_item("A", "feed1", "id-a"),
+            make_item("B", "feed1", "id-b"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let read_ids = HashSet::new();
+
+        let q = make_query(ReadFilter::Read);
+        let summary = format_summary(&refs, &read_ids, &q, false);
+        assert_eq!(summary, "\n2 read posts \u{00b7} 1 feed\n");
+    }
+
+    #[test]
+    fn test_format_summary_any_all_unread() {
+        // When ReadFilter::Any and all shown items are unread, say "unread"
+        let items = vec![
+            make_item("A", "feed1", "id-a"),
+            make_item("B", "feed2", "id-b"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let read_ids = HashSet::new();
+
+        let q = make_query(ReadFilter::Any);
+        let summary = format_summary(&refs, &read_ids, &q, false);
+        assert_eq!(summary, "\n2 unread posts \u{00b7} 2 feeds\n");
+    }
+
+    #[test]
+    fn test_format_summary_any_mixed() {
+        // When ReadFilter::Any but some items are read, don't say "unread"
+        let items = vec![
+            make_item("A", "feed1", "id-a"),
+            make_item("B", "feed2", "id-b"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let mut read_ids = HashSet::new();
+        read_ids.insert("id-a".to_string());
+
+        let q = make_query(ReadFilter::Any);
+        let summary = format_summary(&refs, &read_ids, &q, false);
+        assert_eq!(summary, "\n2 posts \u{00b7} 2 feeds\n");
+    }
 }

--- a/src/display/group.rs
+++ b/src/display/group.rs
@@ -47,15 +47,17 @@ pub(crate) fn render_grouped(items: &[&FeedItem], ctx: &RenderCtx) -> String {
                 s.bold, s.reset
             )
             .unwrap();
-            if depth == 0 {
+            if depth == 0 && !ctx.compact {
                 writeln!(out).unwrap();
             }
             recurse(out, &group_items, rest, ctx);
-            if depth == 0 {
-                writeln!(out).unwrap();
-                writeln!(out).unwrap();
-            } else {
-                writeln!(out).unwrap();
+            if !ctx.compact {
+                if depth == 0 {
+                    writeln!(out).unwrap();
+                    writeln!(out).unwrap();
+                } else {
+                    writeln!(out).unwrap();
+                }
             }
         }
     }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -22,7 +22,7 @@ pub(crate) fn build_feed_labels(fi: &FeedIndex) -> HashMap<String, String> {
         .collect()
 }
 
-pub(super) struct Style {
+pub(crate) struct Style {
     pub bold: &'static str,
     pub dim: &'static str,
     pub italic: &'static str,
@@ -60,6 +60,7 @@ pub(crate) struct RenderCtx<'a> {
     pub color: bool,
     pub shorthand_width: usize,
     pub max_width: Option<usize>,
+    pub compact: bool,
 }
 
 impl<'a> RenderCtx<'a> {
@@ -136,6 +137,7 @@ mod tests {
             read_ids,
             color: false,
             max_width,
+            compact: false,
         }
     }
 
@@ -168,6 +170,7 @@ mod tests {
             color: false,
             shorthand_width: 3,
             max_width: None,
+            compact: false,
         };
         assert_eq!(item::format_item(&i, None, &ctx), expected);
     }
@@ -625,5 +628,62 @@ mod tests {
                 "{title} should be filtered out"
             );
         }
+    }
+
+    #[test]
+    fn test_render_grouped_compact() {
+        let items = [
+            feed_item("Post A", "2024-01-02", "Alice"),
+            feed_item("Post B", "2024-01-02", "Bob"),
+            feed_item("Post C", "2024-01-01", "Alice"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+
+        let keys = [GroupKey::Date];
+        let mut ctx = default_ctx(&keys, no_labels(), no_labels(), no_reads(), None, &refs);
+        ctx.compact = true;
+        let output = render_grouped(&refs, &ctx);
+        assert_eq!(
+            output,
+            "=== 2024-01-02 ===\n  *  Post A (Alice)\n  *  Post B (Bob)\n=== 2024-01-01 ===\n  *  Post C (Alice)\n"
+        );
+    }
+
+    #[test]
+    fn test_render_flat_compact_unchanged() {
+        let items = [
+            feed_item("Post A", "2024-01-02", "Alice"),
+            feed_item("Post B", "2024-01-01", "Bob"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+
+        let mut ctx = default_ctx(&[], no_labels(), no_labels(), no_reads(), None, &refs);
+        ctx.compact = true;
+        let output = render_grouped(&refs, &ctx);
+        // Flat output is unchanged by compact
+        assert_eq!(
+            output,
+            "* 2024-01-02   Post A (Alice)\n* 2024-01-01   Post B (Bob)\n"
+        );
+    }
+
+    #[test]
+    fn test_render_compact_nested_groups() {
+        let items = [
+            feed_item("Post A", "2024-01-02", "Bob"),
+            feed_item("Post B", "2024-01-02", "Alice"),
+            feed_item("Post C", "2024-01-01", "Alice"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+
+        let keys = [GroupKey::Date, GroupKey::Feed];
+        let mut ctx = default_ctx(&keys, no_labels(), no_labels(), no_reads(), None, &refs);
+        ctx.compact = true;
+        let output = render_grouped(&refs, &ctx);
+        // No blank lines anywhere in compact mode
+        assert_eq!(
+            output,
+            "=== 2024-01-02 ===\n  --- Alice ---\n    *  Post B\n  --- Bob ---\n    *  Post A\n=== 2024-01-01 ===\n  --- Alice ---\n    *  Post C\n"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@ use shorthand::RESERVED_COMMANDS;
 struct Args {
     #[command(subcommand)]
     command: Option<Command>,
+
+    /// Use compact output (less whitespace between groups)
+    #[arg(long)]
+    compact: bool,
 }
 
 const QUERY_HELP: &str = "\
@@ -208,12 +212,16 @@ fn run() -> anyhow::Result<()> {
     let mut store = data::BlogData::open(&store_dir)?;
     data::check_schema_version(&mut store)?;
 
+    let show_opts = commands::show::ShowOpts {
+        compact: args.compact || data::get_config_value(&store, "compact") == Some("true".to_string()),
+    };
+
     match args.command {
         // Commands that accept a query/filter
         Some(Command::Show { ref args }) => {
             let all_args: Vec<String> = filter.into_iter().chain(args.iter().cloned()).collect();
             let q = parse_query_or_default(&all_args, &store)?;
-            commands::show::cmd_show(&store, &q)?;
+            commands::show::cmd_show(&store, &q, &show_opts)?;
         }
         Some(Command::Export { ref args }) => {
             let all_args: Vec<String> = filter.into_iter().chain(args.iter().cloned()).collect();
@@ -234,7 +242,7 @@ fn run() -> anyhow::Result<()> {
         }
         None => {
             let q = parse_query_or_default(&filter, &store)?;
-            commands::show::cmd_show(&store, &q)?;
+            commands::show::cmd_show(&store, &q, &show_opts)?;
         }
 
         // Commands that reject filters

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1092,7 +1092,7 @@ fn test_show_displays_post_shorthands() {
     ];
 
     for line in stdout.lines() {
-        if line.trim().is_empty() {
+        if line.trim().is_empty() || line.contains("\u{00b7}") {
             continue;
         }
         // Lines are: "* YYYY-MM-DD  shorthand title (meta)"
@@ -2931,7 +2931,7 @@ fn test_second_sync_with_rotated_posts_stays_unread() {
         .success()
         .stdout_str();
     assert_eq!(
-        before.lines().filter(|l| !l.trim().is_empty()).count(),
+        before.lines().filter(|l| !l.trim().is_empty() && !l.contains("\u{00b7}")).count(),
         1,
         "first sync: expected 1 unread post, got:\n{before}"
     );
@@ -3421,4 +3421,75 @@ fn test_filter_by_id_unknown() {
         stderr.contains("deadbeef12345678") && !stderr.contains("Failed to parse"),
         "error should mention the unknown ID without being a parse error, got:\n{stderr}"
     );
+}
+
+#[test]
+fn test_show_includes_summary_footer() {
+    let ctx = TestContext::new();
+
+    let posts = r#"{"id":"1","title":"Post A","date":"2024-01-15T00:00:00Z","feed":"feed1"}
+{"id":"2","title":"Post B","date":"2024-01-14T00:00:00Z","feed":"feed2"}"#;
+    fs::create_dir_all(ctx.dir.path().join("posts")).unwrap();
+    fs::write(ctx.dir.path().join("posts").join("items_.jsonl"), posts).unwrap();
+
+    let output = ctx.run(&["show", "2020-01-01.."]).success();
+    let stdout = output.stdout_str();
+
+    // Should contain the summary footer with post/feed counts
+    assert!(
+        stdout.contains("posts") && stdout.contains("feeds"),
+        "output should contain summary footer with posts/feeds, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_compact_flag() {
+    let ctx = TestContext::new();
+
+    let posts = r#"{"id":"1","title":"Post A","date":"2024-01-15T00:00:00Z","feed":"Alice"}
+{"id":"2","title":"Post B","date":"2024-01-15T00:00:00Z","feed":"Bob"}
+{"id":"3","title":"Post C","date":"2024-01-14T00:00:00Z","feed":"Alice"}"#;
+    fs::create_dir_all(ctx.dir.path().join("posts")).unwrap();
+    fs::write(ctx.dir.path().join("posts").join("items_.jsonl"), posts).unwrap();
+
+    let output = ctx.run(&["--compact", "show", "/d", "2020-01-01.."]).success();
+    let stdout = output.stdout_str();
+
+    // In compact mode, there should be no blank lines between group header and items
+    let lines: Vec<&str> = stdout.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if line.contains("===") && i + 1 < lines.len() {
+            assert!(
+                !lines[i + 1].trim().is_empty(),
+                "compact mode should not have blank line after group header at line {i}: {line}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_compact_config() {
+    let ctx = TestContext::new();
+
+    let posts = r#"{"id":"1","title":"Post A","date":"2024-01-15T00:00:00Z","feed":"Alice"}
+{"id":"2","title":"Post B","date":"2024-01-14T00:00:00Z","feed":"Bob"}"#;
+    fs::create_dir_all(ctx.dir.path().join("posts")).unwrap();
+    fs::write(ctx.dir.path().join("posts").join("items_.jsonl"), posts).unwrap();
+
+    // Set compact via config
+    ctx.run(&["config", "set", "compact", "true"]).success();
+
+    let output = ctx.run(&["show", "/d", "2020-01-01.."]).success();
+    let stdout = output.stdout_str();
+
+    // In compact mode, there should be no blank lines between group header and items
+    let lines: Vec<&str> = stdout.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if line.contains("===") && i + 1 < lines.len() {
+            assert!(
+                !lines[i + 1].trim().is_empty(),
+                "compact config should not have blank line after group header at line {i}: {line}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Running `blog` with many subscriptions dumps all matching posts as one unbroken wall of text. There's no pagination, no sense of how many posts you're looking at, and grouped output uses generous whitespace that compounds the scroll problem.

## Changes

Three small, independent improvements that each target a different part of the problem:

### 1. Pager integration

Output is piped through a pager when it exceeds terminal height — same behavior as `git log`.

- Activates only when stdout is a TTY **and** output line count > terminal height
- Uses `$PAGER` if set, otherwise `less -R` (preserves ANSI colors)
- Falls back to direct print if the pager fails to spawn
- Ignores broken pipe (user quit pager early — intentional)
- No new config key — `$PAGER` is the standard Unix mechanism; `PAGER=cat` or piping (`blog | cat`) disables it

### 2. Summary footer

A one-line orientation footer appended after the post list:

```
42 unread posts · 3 feeds
```

The status word adapts to the active read filter (`.read` → "read posts", `.all` → "posts", default → "unread posts"). Rendered dim when color is active.

### 3. Compact mode

Opt-in tighter grouped output via `--compact` flag or `blog config set compact true`.

Only affects whitespace in grouped output:
- Removes blank line after group headers
- Removes blank lines between groups

No changes to item format, date format, read markers, or group header text. The density gain comes entirely from whitespace reduction.

```
Default:                         Compact:
=== 2024-W02 ===                 === 2024-W02 ===
                                   * Post A (Alice)
  * Post A (Alice)                 * Post B (Bob)
  * Post B (Bob)                 === 2024-W01 ===
                                   * Post C (Alice)

                                 3 unread posts · 2 feeds
=== 2024-W01 ===

  * Post C (Alice)


3 unread posts · 2 feeds
```

## What this does NOT change

- No new dependencies (uses `std::process` for pager, `terminal_size` is already present)
- No changes to the query language, parser, or grammar
- No changes to item formatting (dates, truncation, read markers)
- No changes to `export`, `feed ls`, `open`, `read`, `sync`, or other commands
- No changes to the data layer or schema

## Testing

- **6 new unit tests** for summary footer formatting (unread, all, singular, read, any-all-unread, any-mixed)
- **3 new display unit tests** for compact rendering (grouped, flat unchanged, nested groups)
- **3 new integration tests** for summary footer presence, `--compact` flag, and compact via config
- **2 existing integration tests** updated to account for the new summary footer line
- Pager has no integration test (requires TTY) but falls back gracefully in piped/test contexts

All 306 tests pass (204 unit + 102 integration).

## Files changed

| File | What |
|---|---|
| `src/commands/show.rs` | `ShowOpts` struct, `format_summary()`, `output_with_pager()`, updated `cmd_show` signature |
| `src/display/group.rs` | Whitespace emission conditionalized on `ctx.compact` |
| `src/display/mod.rs` | `compact: bool` field on `RenderCtx`, `Style` visibility → `pub(crate)` |
| `src/main.rs` | `--compact` flag on `Args`, `ShowOpts` wiring from flag + config |
| `tests/integration.rs` | 3 new tests, 2 existing tests updated |
