### PR TITLE
feat: compact mode for grouped output

### DIFF
--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -9,7 +9,11 @@ use crate::display::{RenderCtx, render_grouped};
 use crate::query::Query;
 use crate::query::resolve::resolve_posts;
 
-pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
+pub(crate) struct ShowOpts {
+    pub compact: bool,
+}
+
+pub(crate) fn cmd_show(store: &BlogData, query: &Query, opts: &ShowOpts) -> anyhow::Result<()> {
     let resolved = resolve_posts(store, query)?;
     ensure!(!resolved.items.is_empty(), "No matching posts");
 
@@ -30,6 +34,7 @@ pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
         color,
         shorthand_width: RenderCtx::shorthand_width_from(&refs, &resolved.shorthands),
         max_width,
+        compact: opts.compact,
     };
     print!("{}", render_grouped(&refs, &ctx));
     Ok(())

--- a/src/display/group.rs
+++ b/src/display/group.rs
@@ -47,15 +47,17 @@ pub(crate) fn render_grouped(items: &[&FeedItem], ctx: &RenderCtx) -> String {
                 s.bold, s.reset
             )
             .unwrap();
-            if depth == 0 {
+            if depth == 0 && !ctx.compact {
                 writeln!(out).unwrap();
             }
             recurse(out, &group_items, rest, ctx);
-            if depth == 0 {
-                writeln!(out).unwrap();
-                writeln!(out).unwrap();
-            } else {
-                writeln!(out).unwrap();
+            if !ctx.compact {
+                if depth == 0 {
+                    writeln!(out).unwrap();
+                    writeln!(out).unwrap();
+                } else {
+                    writeln!(out).unwrap();
+                }
             }
         }
     }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -22,7 +22,7 @@ pub(crate) fn build_feed_labels(fi: &FeedIndex) -> HashMap<String, String> {
         .collect()
 }
 
-pub(super) struct Style {
+pub(crate) struct Style {
     pub bold: &'static str,
     pub dim: &'static str,
     pub italic: &'static str,
@@ -60,6 +60,7 @@ pub(crate) struct RenderCtx<'a> {
     pub color: bool,
     pub shorthand_width: usize,
     pub max_width: Option<usize>,
+    pub compact: bool,
 }
 
 impl<'a> RenderCtx<'a> {
@@ -136,6 +137,7 @@ mod tests {
             read_ids,
             color: false,
             max_width,
+            compact: false,
         }
     }
 
@@ -168,6 +170,7 @@ mod tests {
             color: false,
             shorthand_width: 3,
             max_width: None,
+            compact: false,
         };
         assert_eq!(item::format_item(&i, None, &ctx), expected);
     }
@@ -625,5 +628,87 @@ mod tests {
                 "{title} should be filtered out"
             );
         }
+    }
+
+    #[test]
+    fn test_render_grouped_compact() {
+        let items = [
+            feed_item("Post A", "2024-01-02", "Alice"),
+            feed_item("Post B", "2024-01-02", "Bob"),
+            feed_item("Post C", "2024-01-01", "Alice"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+
+        let keys = [GroupKey::Date];
+        let ctx = RenderCtx {
+            all_keys: &keys,
+            shorthand_width: RenderCtx::shorthand_width_from(&refs, &HashMap::new()),
+            shorthands: no_labels(),
+            feed_labels: no_labels(),
+            read_ids: no_reads(),
+            color: false,
+            max_width: None,
+            compact: true,
+        };
+        let output = render_grouped(&refs, &ctx);
+        // Compact: no blank line after header, no blank lines between groups
+        assert_eq!(
+            output,
+            "=== 2024-01-02 ===\n  *  Post A (Alice)\n  *  Post B (Bob)\n=== 2024-01-01 ===\n  *  Post C (Alice)\n"
+        );
+    }
+
+    #[test]
+    fn test_render_grouped_compact_flat_unchanged() {
+        let items = [
+            feed_item("Post A", "2024-01-02", "Alice"),
+            feed_item("Post B", "2024-01-01", "Bob"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+
+        let ctx = RenderCtx {
+            all_keys: &[],
+            shorthand_width: RenderCtx::shorthand_width_from(&refs, &HashMap::new()),
+            shorthands: no_labels(),
+            feed_labels: no_labels(),
+            read_ids: no_reads(),
+            color: false,
+            max_width: None,
+            compact: true,
+        };
+        let output = render_grouped(&refs, &ctx);
+        // Flat output is identical whether compact or not
+        assert_eq!(
+            output,
+            "* 2024-01-02   Post A (Alice)\n* 2024-01-01   Post B (Bob)\n"
+        );
+    }
+
+    #[test]
+    fn test_render_grouped_compact_nested() {
+        let items = [
+            feed_item("Post A", "2024-01-02", "Alice"),
+            feed_item("Post B", "2024-01-02", "Bob"),
+            feed_item("Post C", "2024-01-01", "Alice"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+
+        let keys = [GroupKey::Date, GroupKey::Feed];
+        let ctx = RenderCtx {
+            all_keys: &keys,
+            shorthand_width: RenderCtx::shorthand_width_from(&refs, &HashMap::new()),
+            shorthands: no_labels(),
+            feed_labels: no_labels(),
+            read_ids: no_reads(),
+            color: false,
+            max_width: None,
+            compact: true,
+        };
+        let output = render_grouped(&refs, &ctx);
+        // Top-level has no extra blank lines; nested still has separator
+        assert_eq!(
+            output,
+            "=== 2024-01-02 ===\n  --- Alice ---\n    *  Post A\n  --- Bob ---\n    *  Post B\n=== 2024-01-01 ===\n  --- Alice ---\n    *  Post C\n"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ use shorthand::RESERVED_COMMANDS;
 struct Args {
     #[command(subcommand)]
     command: Option<Command>,
+    /// Use compact output (less whitespace between groups)
+    #[arg(long)]
+    compact: bool,
 }
 
 const QUERY_HELP: &str = "\
@@ -208,12 +211,15 @@ fn run() -> anyhow::Result<()> {
     let mut store = data::BlogData::open(&store_dir)?;
     data::check_schema_version(&mut store)?;
 
+    let show_opts = commands::show::ShowOpts {
+        compact: args.compact || data::get_config_value(&store, "compact") == Some("true".to_string()),
+    };
     match args.command {
         // Commands that accept a query/filter
         Some(Command::Show { ref args }) => {
             let all_args: Vec<String> = filter.into_iter().chain(args.iter().cloned()).collect();
             let q = parse_query_or_default(&all_args, &store)?;
-            commands::show::cmd_show(&store, &q)?;
+            commands::show::cmd_show(&store, &q, &show_opts)?;
         }
         Some(Command::Export { ref args }) => {
             let all_args: Vec<String> = filter.into_iter().chain(args.iter().cloned()).collect();
@@ -234,7 +240,7 @@ fn run() -> anyhow::Result<()> {
         }
         None => {
             let q = parse_query_or_default(&filter, &store)?;
-            commands::show::cmd_show(&store, &q)?;
+            commands::show::cmd_show(&store, &q, &show_opts)?;
         }
 
         // Commands that reject filters

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3422,3 +3422,56 @@ fn test_filter_by_id_unknown() {
         "error should mention the unknown ID without being a parse error, got:\n{stderr}"
     );
 }
+
+
+#[test]
+fn test_compact_flag() {
+    let ctx = TestContext::new();
+
+    let posts = r#"{"id":"1","title":"Post A","date":"2024-01-15T00:00:00Z","feed":"Alice"}
+{"id":"2","title":"Post B","date":"2024-01-15T00:00:00Z","feed":"Bob"}
+{"id":"3","title":"Post C","date":"2024-01-14T00:00:00Z","feed":"Alice"}"#;
+    fs::create_dir_all(ctx.dir.path().join("posts")).unwrap();
+    fs::write(ctx.dir.path().join("posts").join("items_.jsonl"), posts).unwrap();
+
+    let output = ctx.run(&["--compact", "show", "/d", "2020-01-01.."]).success();
+    let stdout = output.stdout_str();
+
+    // In compact mode, there should be no blank lines between group header and items
+    let lines: Vec<&str> = stdout.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if line.contains("===") && i + 1 < lines.len() {
+            assert!(
+                !lines[i + 1].trim().is_empty(),
+                "compact mode should not have blank line after group header at line {i}: {line}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_compact_config() {
+    let ctx = TestContext::new();
+
+    let posts = r#"{"id":"1","title":"Post A","date":"2024-01-15T00:00:00Z","feed":"Alice"}
+{"id":"2","title":"Post B","date":"2024-01-14T00:00:00Z","feed":"Bob"}"#;
+    fs::create_dir_all(ctx.dir.path().join("posts")).unwrap();
+    fs::write(ctx.dir.path().join("posts").join("items_.jsonl"), posts).unwrap();
+
+    // Set compact via config
+    ctx.run(&["config", "set", "compact", "true"]).success();
+
+    let output = ctx.run(&["show", "/d", "2020-01-01.."]).success();
+    let stdout = output.stdout_str();
+
+    // In compact mode, there should be no blank lines between group header and items
+    let lines: Vec<&str> = stdout.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if line.contains("===") && i + 1 < lines.len() {
+            assert!(
+                !lines[i + 1].trim().is_empty(),
+                "compact config should not have blank line after group header at line {i}: {line}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Opt-in tighter grouped output via `--compact` flag or `blog config set compact true`.

Only affects whitespace in grouped output:
- Removes blank line after group headers
- Removes blank lines between groups

No changes to item format, date format, read markers, or group header text. The density gain comes entirely from whitespace reduction.

```
Default:                         Compact:
=== 2024-W02 ===                 === 2024-W02 ===
                                   * Post A (Alice)
  * Post A (Alice)                 * Post B (Bob)
  * Post B (Bob)                 === 2024-W01 ===
                                   * Post C (Alice)

=== 2024-W01 ===

  * Post C (Alice)
```

## Files changed

| File | What |
|---|---|
| `src/commands/show.rs` | `ShowOpts` struct, `compact` field wired to `RenderCtx` |
| `src/display/mod.rs` | `compact: bool` on `RenderCtx`, `Style` visibility → `pub(crate)` |
| `src/display/group.rs` | Whitespace emission conditionalized on `ctx.compact` |
| `src/main.rs` | `--compact` flag on `Args`, `ShowOpts` wiring from flag + config |
| `tests/integration.rs` | 2 new integration tests |

## Testing

- 3 new unit tests (compact grouped, flat unchanged, nested groups)
- 2 new integration tests (`--compact` flag, compact via config)
- All existing tests pass

Split from #166 per review feedback.