### PR TITLE
feat: summary footer with query echo

### DIFF
--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -5,11 +5,11 @@ use anyhow::ensure;
 
 use crate::data::BlogData;
 use crate::data::schema::FeedItem;
-use crate::display::{RenderCtx, render_grouped};
+use crate::display::{RenderCtx, Style, render_grouped};
 use crate::query::Query;
 use crate::query::resolve::resolve_posts;
 
-pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
+pub(crate) fn cmd_show(store: &BlogData, query: &Query, query_text: &str) -> anyhow::Result<()> {
     let resolved = resolve_posts(store, query)?;
     ensure!(!resolved.items.is_empty(), "No matching posts");
 
@@ -32,5 +32,92 @@ pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
         max_width,
     };
     print!("{}", render_grouped(&refs, &ctx));
+
+    // Summary goes to stderr so it doesn't pollute piped/redirected output
+    eprint!("{}", format_summary(&refs, query_text, color));
+
     Ok(())
+}
+
+pub(crate) fn format_summary(
+    items: &[&FeedItem],
+    query_text: &str,
+    color: bool,
+) -> String {
+    let count = items.len();
+    let feed_count = {
+        let mut feeds: Vec<&str> = items.iter().map(|i| i.feed.as_str()).collect();
+        feeds.sort_unstable();
+        feeds.dedup();
+        feeds.len()
+    };
+
+    let s = Style::new(color);
+    format!(
+        "{}{count} Post(s) from {feed_count} Feed(s) ({query_text}){}\n",
+        s.dim, s.reset
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item(title: &str, feed: &str, raw_id: &str) -> FeedItem {
+        FeedItem {
+            title: title.to_string(),
+            date: None,
+            feed: feed.to_string(),
+            link: String::new(),
+            raw_id: raw_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_format_summary_multiple_posts_multiple_feeds() {
+        let items = vec![
+            make_item("A", "feed1", "id-a"),
+            make_item("B", "feed2", "id-b"),
+            make_item("C", "feed1", "id-c"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let summary = format_summary(&refs, ".unread 90d.. /w", false);
+        assert_eq!(summary, "3 Post(s) from 2 Feed(s) (.unread 90d.. /w)\n");
+    }
+
+    #[test]
+    fn test_format_summary_single_post_single_feed() {
+        let items = vec![make_item("A", "feed1", "id-a")];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let summary = format_summary(&refs, ".all", false);
+        assert_eq!(summary, "1 Post(s) from 1 Feed(s) (.all)\n");
+    }
+
+    #[test]
+    fn test_format_summary_custom_query() {
+        let items = vec![
+            make_item("A", "feed1", "id-a"),
+            make_item("B", "feed2", "id-b"),
+        ];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let summary = format_summary(&refs, "@myblog .read 2w..", false);
+        assert_eq!(summary, "2 Post(s) from 2 Feed(s) (@myblog .read 2w..)\n");
+    }
+
+    #[test]
+    fn test_format_summary_no_color_no_ansi() {
+        let items = vec![make_item("A", "feed1", "id-a")];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let summary = format_summary(&refs, ".unread", false);
+        assert!(!summary.contains("\x1b"));
+    }
+
+    #[test]
+    fn test_format_summary_color_has_dim() {
+        let items = vec![make_item("A", "feed1", "id-a")];
+        let refs: Vec<&FeedItem> = items.iter().collect();
+        let summary = format_summary(&refs, ".unread", true);
+        assert!(summary.contains("\x1b[2m"));
+        assert!(summary.contains("\x1b[0m"));
+    }
 }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -22,7 +22,7 @@ pub(crate) fn build_feed_labels(fi: &FeedIndex) -> HashMap<String, String> {
         .collect()
 }
 
-pub(super) struct Style {
+pub(crate) struct Style {
     pub bold: &'static str,
     pub dim: &'static str,
     pub italic: &'static str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,12 +179,14 @@ fn store_dir() -> anyhow::Result<PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("could not determine data directory; set RSS_STORE"))
 }
 
-fn parse_query_or_default(args: &[String], store: &data::BlogData) -> anyhow::Result<query::Query> {
+fn parse_query_or_default(args: &[String], store: &data::BlogData) -> anyhow::Result<(query::Query, String)> {
     if args.is_empty() {
         let default = data::get_config_value(store, "default_query");
-        query::parse_query_str(default.as_deref().unwrap_or(query::DEFAULT_QUERY))
+        let text = default.as_deref().unwrap_or(query::DEFAULT_QUERY);
+        Ok((query::parse_query_str(text)?, text.to_string()))
     } else {
-        query::parse_query(args)
+        let text = args.join(" ");
+        Ok((query::parse_query(args)?, text))
     }
 }
 
@@ -212,12 +214,12 @@ fn run() -> anyhow::Result<()> {
         // Commands that accept a query/filter
         Some(Command::Show { ref args }) => {
             let all_args: Vec<String> = filter.into_iter().chain(args.iter().cloned()).collect();
-            let q = parse_query_or_default(&all_args, &store)?;
-            commands::show::cmd_show(&store, &q)?;
+            let (q, query_text) = parse_query_or_default(&all_args, &store)?;
+            commands::show::cmd_show(&store, &q, &query_text)?;
         }
         Some(Command::Export { ref args }) => {
             let all_args: Vec<String> = filter.into_iter().chain(args.iter().cloned()).collect();
-            let q = parse_query_or_default(&all_args, &store)?;
+            let (q, _) = parse_query_or_default(&all_args, &store)?;
             commands::export::cmd_export(&store, &q)?;
         }
         Some(Command::Open) => {
@@ -233,8 +235,8 @@ fn run() -> anyhow::Result<()> {
             commands::open::cmd_unread(&mut store, &q)?;
         }
         None => {
-            let q = parse_query_or_default(&filter, &store)?;
-            commands::show::cmd_show(&store, &q)?;
+            let (q, query_text) = parse_query_or_default(&filter, &store)?;
+            commands::show::cmd_show(&store, &q, &query_text)?;
         }
 
         // Commands that reject filters

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3422,3 +3422,22 @@ fn test_filter_by_id_unknown() {
         "error should mention the unknown ID without being a parse error, got:\n{stderr}"
     );
 }
+
+#[test]
+fn test_show_includes_summary_footer() {
+    let ctx = TestContext::new();
+
+    let posts = r#"{"id":"1","title":"Post A","date":"2024-01-15T00:00:00Z","feed":"feed1"}
+{"id":"2","title":"Post B","date":"2024-01-14T00:00:00Z","feed":"feed2"}"#;
+    fs::create_dir_all(ctx.dir.path().join("posts")).unwrap();
+    fs::write(ctx.dir.path().join("posts").join("items_.jsonl"), posts).unwrap();
+
+    let output = ctx.run(&["show", "2020-01-01.."]).success();
+    let stderr = output.stderr_str();
+
+    // Summary footer goes to stderr with post/feed counts and the query
+    assert!(
+        stderr.contains("Post(s)") && stderr.contains("Feed(s)") && stderr.contains("2020-01-01.."),
+        "stderr should contain summary footer with counts and query, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
A one-line summary printed to stderr after the post list, showing counts and the executed query:

```
3 Post(s) from 2 Feed(s) (.unread 90d.. /w)
```

- Written to **stderr** so `blog > file` keeps clean data
- Shows the actual query that was executed, including implicit defaults
- Rendered dim when color is active

## Files changed

| File | What |
|---|---|
| `src/commands/show.rs` | `format_summary()`, `query_text` param on `cmd_show`, summary to stderr |
| `src/display/mod.rs` | `Style` visibility → `pub(crate)` |
| `src/main.rs` | `parse_query_or_default` returns `(Query, String)`, query text threaded to `cmd_show` |
| `tests/integration.rs` | 1 new integration test |

## Testing

- 5 new unit tests (counts, query text, singular, color/no-color)
- 1 new integration test (stderr output)
- All existing tests pass

Split from #166 per review feedback. Incorporates suggestions from @kantord to show the executed query and write to stderr.