### PR TITLE
feat: pipe output through pager when it exceeds terminal height

### DIFF
--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal, Write};
 
 use anyhow::ensure;
 
@@ -20,7 +20,8 @@ pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
         .collect();
 
     let color = std::io::stdout().is_terminal();
-    let max_width = terminal_size::terminal_size().map(|(w, _)| w.0 as usize);
+    let terminal = terminal_size::terminal_size();
+    let max_width = terminal.map(|(w, _)| w.0 as usize);
     let refs: Vec<&FeedItem> = resolved.items.iter().map(|(_, item)| item).collect();
     let ctx = RenderCtx {
         all_keys: &query.keys,
@@ -31,6 +32,63 @@ pub(crate) fn cmd_show(store: &BlogData, query: &Query) -> anyhow::Result<()> {
         shorthand_width: RenderCtx::shorthand_width_from(&refs, &resolved.shorthands),
         max_width,
     };
-    print!("{}", render_grouped(&refs, &ctx));
+    let mut output = render_grouped(&refs, &ctx);
+    // Trim trailing blank lines from grouped output
+    let trimmed_len = output.trim_end().len();
+    output.truncate(trimmed_len);
+    output.push('\n');
+
+    let is_tty = std::io::stdout().is_terminal();
+    let term_height = terminal.map(|(_, h)| h.0 as usize).unwrap_or(usize::MAX);
+    let line_count = output.lines().count();
+
+    if is_tty && line_count > term_height {
+        if output_with_pager(&output).is_err() {
+            print!("{output}");
+        }
+    } else {
+        print!("{output}");
+    }
+
+    Ok(())
+}
+
+fn output_with_pager(content: &str) -> io::Result<()> {
+    let pager_env = std::env::var("PAGER").ok();
+    let (bin, args) = match &pager_env {
+        Some(val) => {
+            let val = val.trim();
+            match val.split_once(char::is_whitespace) {
+                Some((b, a)) => (b.to_string(), vec![a.to_string()]),
+                None => {
+                    let mut args = Vec::new();
+                    if val == "less" {
+                        args.push("-R".to_string());
+                    }
+                    (val.to_string(), args)
+                }
+            }
+        }
+        None => ("less".to_string(), vec!["-R".to_string()]),
+    };
+
+    let mut child = std::process::Command::new(&bin)
+        .args(&args)
+        .stdin(std::process::Stdio::piped())
+        .spawn()?;
+
+    let result = child.stdin.as_mut().unwrap().write_all(content.as_bytes());
+
+    // Ignore broken pipe — user quit the pager early, which is intentional
+    if let Err(ref e) = result {
+        if e.kind() != io::ErrorKind::BrokenPipe {
+            result?;
+        }
+    }
+
+    // Drop stdin to signal EOF
+    drop(child.stdin.take());
+
+    let _ = child.wait();
     Ok(())
 }


### PR DESCRIPTION
Output is piped through a pager when it exceeds terminal height — same behavior as `git log`.

- Activates only when stdout is a TTY **and** output line count > terminal height
- Uses `$PAGER` if set, otherwise `less -R` (preserves ANSI colors)
- Falls back to direct print if the pager fails to spawn
- Ignores broken pipe (user quit pager early — intentional)
- `PAGER=cat` or piping (`blog | cat`) disables it
- No new dependencies (uses `std::process` for pager, `terminal_size` is already present)

## Files changed

| File | What |
|---|---|
| `src/commands/show.rs` | `output_with_pager()`, output buffering, TTY/height gating |

## Testing

No integration test (requires TTY). Falls back gracefully in piped/test contexts. All existing tests pass.

Split from #166 per review feedback.