### PR TITLE
fix: use sort_by instead of sort_by_key for date ordering

### DIFF
--- a/src/feed/pull.rs
+++ b/src/feed/pull.rs
@@ -55,7 +55,7 @@ pub(crate) fn initial_read_ids(items: &[FeedItem], now: DateTime<Utc>) -> Vec<St
         .iter()
         .filter(|i| matches!(i.date, Some(d) if d >= two_months_ago))
         .collect();
-    recent.sort_by_key(|b| std::cmp::Reverse(b.date));
+    recent.sort_by(|a, b| b.date.cmp(&a.date));
 
     let unread_ids: std::collections::HashSet<&str> = if recent.is_empty() {
         // All posts are old or dateless — keep the single most recent unread


### PR DESCRIPTION
Replace `sort_by_key(|b| std::cmp::Reverse(b.date))` with `sort_by(|a, b| b.date.cmp(&a.date))` in `initial_read_ids`.

Avoids the `Reverse` wrapper on `Option<DateTime>`.

## Files changed

| File | What |
|---|---|
| `src/feed/pull.rs` | One-line sort change |

## Testing

Covered by existing tests. All pass.

Split from #166 per review feedback.