### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ These are mature, self-hostable web-based RSS readers/aggregators. What
 zero-setup sync between different machines using `git`, without the need for an
 additional, continuously running server.
 
-### [Feedly](https://feedly.com/), [Inoreader](https://www.inoreader.com/)
+### [Feedly](https://feedly.com/i/discover/), [Inoreader](https://www.inoreader.com/)
 
 These are full-featured web-based services. If you are a heavy RSS-user and
 like the user interfaces and features they offer (such as GUI apps for iOS and


### PR DESCRIPTION
It seems that Feedly is not purely an RSS management software anymore. Feedly.com is now an AI company, but https://feedly.com/i/discover is the RSS thing. But from the latter UI it seems like it has nothing to do with the former.