### PR TITLE
ci: run cargo test in existing CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,6 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo test --workspace --all-features
       - run: cargo install --locked prek
       - run: prek run --all-files


### PR DESCRIPTION
## Summary

This repo's `.github/workflows/ci.yml` already runs `prek run --all-files` (a pre-commit-style check) but never actually ran `cargo test`. This adds a `cargo test --workspace --all-features` step to the existing job, matching the workflow's current style (same checkout/toolchain/cache actions, same matrix, same triggers) rather than introducing a separate parallel workflow.

## Disclosure

This change was made fully automatically, not by a human, using the script at
https://github.com/kantord/meta.op/blob/67c095e524d41b8227b6a437008564785bf1dd60/ci/cargo-test-coverage.op.tsx
(commit `67c095e524d41b8227b6a437008564785bf1dd60`).

## Test plan

- [x] CI runs on this PR and the new `cargo test --workspace --all-features` step executes successfully