### PR TITLE
Add cargo test step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,4 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo install --locked prek
       - run: prek run --all-files
+      - run: cargo test --workspace --all-features


### PR DESCRIPTION
This change was made fully automatically, not by a human, using the script at
https://github.com/kantord/meta.op/blob/798b65cb21806c9ca990d73033c9e139aafb83cd/ci/cargo-test-coverage.op.tsx
(commit 798b65cb21806c9ca990d73033c9e139aafb83cd).