### PR TITLE
feat: add no-remote flag to command sync

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -96,19 +96,26 @@ fn resolve_sync_sources(
     Ok(resolved)
 }
 
-pub(crate) fn cmd_sync(store: &mut BlogData, selectors: &[String]) -> anyhow::Result<()> {
-    // Sync with remote first so we discover feeds added on other devices
-    let result = do_sync_remote(store)?;
-
-    let needs_push = match result {
-        SyncResult::NoRemote => {
-            eprintln!(
-                "warning: no remote configured; run `blog git remote add origin <url>` to enable sync"
-            );
-            false
+pub(crate) fn cmd_sync(
+    store: &mut BlogData,
+    selectors: &[String],
+    no_remote: bool,
+) -> anyhow::Result<()> {
+    let needs_push = if !no_remote {
+        // Sync with remote first so we discover feeds added on other devices
+        let result = do_sync_remote(store)?;
+        match result {
+            SyncResult::NoRemote => {
+                eprintln!(
+                    "warning: no remote configured; run `blog git remote add origin <url>` to enable sync"
+                );
+                false
+            }
+            SyncResult::NoGitRepo => false,
+            SyncResult::Synced | SyncResult::AlreadyUpToDate => true,
         }
-        SyncResult::NoGitRepo => false,
-        SyncResult::Synced | SyncResult::AlreadyUpToDate => true,
+    } else {
+        false
     };
 
     let fi = feed_index(store.feeds());

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,27 +415,58 @@ mod tests {
     #[test]
     fn test_parse_sync_without_feed_selectors() {
         let args = Args::parse_from(args(&["blog", "sync"]));
-        let Some(Command::Sync { feeds }) = args.command else {
+        let Some(Command::Sync { feeds, no_remote }) = args.command else {
             panic!("expected sync command");
         };
         assert!(feeds.is_empty());
+        assert_eq!(no_remote, false);
     }
 
     #[test]
     fn test_parse_sync_with_one_feed_selector() {
         let args = Args::parse_from(args(&["blog", "sync", "--feed", "@df"]));
-        let Some(Command::Sync { feeds }) = args.command else {
+        let Some(Command::Sync { feeds, no_remote }) = args.command else {
             panic!("expected sync command");
         };
         assert_eq!(feeds, vec!["@df"]);
+        assert_eq!(no_remote, false);
     }
 
     #[test]
     fn test_parse_sync_with_multiple_feed_selectors() {
         let args = Args::parse_from(args(&["blog", "sync", "--feed", "@df", "--feed", "@dg"]));
-        let Some(Command::Sync { feeds }) = args.command else {
+        let Some(Command::Sync { feeds, no_remote }) = args.command else {
             panic!("expected sync command");
         };
         assert_eq!(feeds, vec!["@df", "@dg"]);
+        assert_eq!(no_remote, false);
+    }
+
+    #[test]
+    fn test_parse_sync_with_no_remote() {
+        let args = Args::parse_from(args(&["blog", "sync", "--no-remote"]));
+        let Some(Command::Sync { feeds, no_remote }) = args.command else {
+            panic!("expected sync command");
+        };
+        assert!(feeds.is_empty());
+        assert_eq!(no_remote, true);
+    }
+
+    #[test]
+    fn test_parse_sync_with_feed_selectors_and_no_remote() {
+        let args = Args::parse_from(args(&[
+            "blog",
+            "sync",
+            "--feed",
+            "@df",
+            "--no-remote",
+            "--feed",
+            "@dg",
+        ]));
+        let Some(Command::Sync { feeds, no_remote }) = args.command else {
+            panic!("expected sync command");
+        };
+        assert_eq!(feeds, vec!["@df", "@dg"]);
+        assert_eq!(no_remote, true);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,9 @@ enum Command {
         /// Repeat to sync only selected feeds by @shorthand
         #[arg(long = "feed", value_name = "SHORTHAND")]
         feeds: Vec<String>,
+        /// Do not interact with the remote repository
+        #[arg(long)]
+        no_remote: bool,
     },
     /// Mark a post as unread
     Unread,
@@ -289,9 +292,12 @@ fn run() -> anyhow::Result<()> {
             commands::import::cmd_import(&mut store, path)?;
         }
 
-        Some(Command::Sync { ref feeds }) => {
+        Some(Command::Sync {
+            ref feeds,
+            no_remote,
+        }) => {
             reject_filter(&filter, "sync")?;
-            commands::sync::cmd_sync(&mut store, feeds)?;
+            commands::sync::cmd_sync(&mut store, feeds, no_remote)?;
         }
         Some(Command::Git { ref args }) => {
             reject_filter(&filter, "git")?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1705,6 +1705,94 @@ fn test_sync_local_ahead_only() {
 }
 
 #[test]
+fn test_sync_no_remote_still_fetches_posts() {
+    let dir = TempDir::new().unwrap();
+    let server = MockServer::start();
+    let xml = rss_xml(
+        "Test Feed",
+        &[("Test Post", "Mon, 01 Jan 2024 00:00:00 +0000")],
+    );
+    server.mock(|when, then| {
+        when.method(GET).path("/feed.xml");
+        then.status(200)
+            .header("Content-Type", "application/rss+xml")
+            .body(&xml);
+    });
+    let url = server.url("/feed.xml");
+
+    // Initial git repo, like init_git_store without adding remote
+    git(dir.path(), &["init"]);
+    git_config_test_user(dir.path());
+    fs::write(dir.path().join(".keep"), "").unwrap();
+    git(dir.path(), &["add", "."]);
+    git(dir.path(), &["commit", "-m", "init"]);
+
+    insert_feed(dir.path(), &url);
+    run_blog(dir.path(), &["sync", "--no-remote"]).success();
+
+    let posts = read_table(&dir.path().join("posts"));
+    assert!(
+        posts
+            .iter()
+            .any(|p| p["title"].as_str() == Some("Test Post")),
+        "--no-remote should still fetch posts locally, got: {posts:?}"
+    );
+}
+
+#[test]
+fn test_sync_no_remote_does_not_pull_remote_feed() {
+    let origin_dir = TempDir::new().unwrap();
+    git(origin_dir.path(), &["init", "--bare"]);
+
+    let store_dir = TempDir::new().unwrap();
+    init_git_store(store_dir.path(), origin_dir.path());
+
+    // Remote device adds a feed and pushes
+    let (other_td, other_dir) = clone_store(origin_dir.path());
+    insert_feed(&other_dir, "https://example.com/remote.xml");
+    git(&other_dir, &["push", "origin", "HEAD"]);
+    drop(other_td);
+
+    // Sync without remote should NOT merge in the remote feed
+    run_blog(store_dir.path(), &["sync", "--no-remote"]).success();
+
+    // Verify
+    let feeds = read_table(&store_dir.path().join("feeds"));
+    assert!(
+        !feeds
+            .iter()
+            .any(|f| f["url"].as_str() == Some("https://example.com/remote.xml")),
+        "--no-remote should not pull the remote feed, got: {feeds:?}"
+    );
+}
+
+#[test]
+fn test_sync_no_remote_does_not_push() {
+    let origin_dir = TempDir::new().unwrap();
+    git(origin_dir.path(), &["init", "--bare"]);
+
+    let store_dir = TempDir::new().unwrap();
+    init_git_store(store_dir.path(), origin_dir.path());
+
+    // Add a feed locally (auto-committed)
+    insert_feed(store_dir.path(), "https://example.com/a.xml");
+
+    // Sync with --no-remote should NOT push local changes
+    run_blog(store_dir.path(), &["sync", "--no-remote"]).success();
+
+    // Verify
+    let (clone_td, clone_dir) = clone_store(origin_dir.path());
+    let feeds = read_table(&clone_dir.join("feeds"));
+    assert!(
+        !feeds
+            .iter()
+            .any(|f| f["url"].as_str() == Some("https://example.com/a.xml")),
+        "--no-remote should not push the local feed to remote, got: {feeds:?}"
+    );
+    drop(clone_td);
+}
+
+#[test]
 fn test_sync_remote_ahead_only() {
     let origin_dir = TempDir::new().unwrap();
     git(origin_dir.path(), &["init", "--bare"]);


### PR DESCRIPTION
When using `blog sync --no-remote`, it will only fetch the feeds and won't push local change or merge with remote change.