### PR TITLE
fix: stop fetch/push spinner from clobbering ssh passphrase prompt

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -7,7 +7,7 @@ use synctato::{SyncEvent, SyncResult};
 use crate::data::BlogData;
 use crate::data::index::{FeedIndex, feed_index};
 use crate::data::schema::FeedSource;
-use crate::utils::progress::spinner;
+use crate::utils::progress::{spinner, static_spinner};
 use crate::utils::version_check::check_for_newer_version;
 
 use crate::feed::pull::{apply_fetched, fetch_feeds};
@@ -21,7 +21,9 @@ fn do_sync_remote(store: &mut BlogData) -> anyhow::Result<SyncResult> {
     let mut sp: Option<ProgressBar> = None;
     store.sync_remote(|event| match event {
         SyncEvent::Fetching => {
-            sp = Some(spinner("Fetching..."));
+            // Non-animated: `git fetch` over ssh may need to prompt for a key
+            // passphrase, and a steady-tick spinner would redraw over it.
+            sp = Some(static_spinner("Fetching..."));
         }
         SyncEvent::FetchDone => {
             if let Some(s) = sp.take() {
@@ -34,7 +36,8 @@ fn do_sync_remote(store: &mut BlogData) -> anyhow::Result<SyncResult> {
             } else {
                 "Pushing..."
             };
-            sp = Some(spinner(msg));
+            // Same reasoning as Fetching: `git push` over ssh may prompt too.
+            sp = Some(static_spinner(msg));
         }
         SyncEvent::PushDone { first_push } => {
             let msg = if first_push {

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -3,6 +3,22 @@ use std::time::Duration;
 use indicatif::{ProgressBar, ProgressStyle};
 
 pub(crate) fn spinner(msg: &str) -> ProgressBar {
+    let pb = spinner_with_style(msg);
+    pb.enable_steady_tick(Duration::from_millis(100));
+    pb
+}
+
+/// Like [`spinner`], but without a self-ticking redraw thread.
+///
+/// Use this for operations where another process may print straight to the
+/// terminal (e.g. `ssh` prompting for a key passphrase): indicatif's steady
+/// tick redraws the spinner's line every interval, which clobbers whatever
+/// that other process just wrote there.
+pub(crate) fn static_spinner(msg: &str) -> ProgressBar {
+    spinner_with_style(msg)
+}
+
+fn spinner_with_style(msg: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
     pb.set_style(
         ProgressStyle::default_spinner()
@@ -10,6 +26,5 @@ pub(crate) fn spinner(msg: &str) -> ProgressBar {
             .unwrap(),
     );
     pb.set_message(msg.to_string());
-    pb.enable_steady_tick(Duration::from_millis(100));
     pb
 }


### PR DESCRIPTION


fixes #217 